### PR TITLE
[MRG] Add giovanni CLI to PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,21 @@ generation of Pokemon.
 Compute the probability of encountering a shiny in Gen 4 with a single encounter:
 
 ```
-$ python -m giovanni odds --gen 4 --verbose
+$ giovanni odds --gen 4 --verbose
 [INFO] 2020-12-22 16:07:54 [giovanni.cli.odds] - Odds of shiny after 1 soft reset: 0.012%
 ```
 
 The probability of encountering a shiny in Gen 6 with 5000 SRs and a shiny charm equipped:
 
 ```
-$ python -m giovanni odds --gen 6 --soft_resets 5000 --charm
+$ giovanni odds --gen 6 --soft_resets 5000 --charm
 [INFO] 2020-12-22 16:07:57 [giovanni.cli.odds] - Odds of shiny after 5,000 soft resets: 91.301%
 ```
 
 The odds of encountering a shiny starter in HG/SS after 2500 SRs:
 
 ```
-$ python -m giovanni odds --gen 4 --soft_resets 2500 --swarm_size 3
+$ giovanni odds --gen 4 --soft_resets 2500 --swarm_size 3
 [INFO] 2020-12-24 07:40:44 [giovanni.cli.odds] - Odds of shiny after 2,500 soft resets: 59.972%
 ```
 
@@ -34,7 +34,7 @@ $ python -m giovanni odds --gen 4 --soft_resets 2500 --swarm_size 3
 A simulation of Gen 6 soft resets required to encounter a shiny:
 
 ```
-$ python -m giovanni simulate --gen 6 -n 5000
+$ giovanni simulate --gen 6 -n 5000
 simulation: 100%|████████████████████████████████████████████| 5000/5000 [00:13<00:00, 365.02it/s]
 [INFO] 2020-12-22 15:53:43 [giovanni.cli.simulate] - Montecarlo simulation results --
 Average     3980.136
@@ -48,7 +48,7 @@ To simulate, e.g., SS/HG soft resets required to encounter a shiny starter use
 the `swarm_size` argument:
 
 ```
-python -m giovanni simulate --gen 4 -n 5000 --swarm_size 3
+$ giovanni simulate --gen 4 -n 5000 --swarm_size 3
 simulation: 100%|████████████████████████████████████████████| 5000/5000 [00:15<00:00, 329.87it/s]
 [INFO] 2020-12-22 15:51:01 [giovanni.cli.simulate] - Montecarlo simulation results --
 Average     2737.669
@@ -89,6 +89,12 @@ giovanni is available on public PyPi:
 
 ```bash
 $ pip install giovanni
+```
+
+Once installed, it can be used like so:
+
+```bash
+$ giovanni odds --gen 4
 ```
 
 ### Get setup for local dev:

--- a/bin/giovanni
+++ b/bin/giovanni
@@ -1,0 +1,3 @@
+from giovanni.cli import main
+
+sys.exit(main.main())

--- a/bin/giovanni
+++ b/bin/giovanni
@@ -1,5 +1,0 @@
-import sys
-
-from giovanni.cli import main
-
-sys.exit(main.main())

--- a/bin/giovanni
+++ b/bin/giovanni
@@ -1,3 +1,5 @@
+import sys
+
 from giovanni.cli import main
 
 sys.exit(main.main())

--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,7 @@ setup(
     zip_safe=False,
     install_requires=req_file,
     python_requires=f'>={MIN_PYTHON[0]}.{MIN_PYTHON[1]}',
-    scripts=['bin/giovanni'],
+    entry_points={
+        'console_scripts': ['giovanni=giovanni.cli.main:main']
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -46,4 +46,5 @@ setup(
     zip_safe=False,
     install_requires=req_file,
     python_requires=f'>={MIN_PYTHON[0]}.{MIN_PYTHON[1]}',
+    scripts=['bin/giovanni'],
 )


### PR DESCRIPTION
This PR makes it so once you `pip install`, you just have to call `giovanni` to interact with the CLI. `setuptools` creates this script for us at install time:

```bash
 $ cat /Users/asmith/Library/Python/3.7/bin/giovanni
#!/Library/Developer/CommandLineTools/usr/bin/python3
# -*- coding: utf-8 -*-
import re
import sys
from giovanni.cli.main import main
if __name__ == '__main__':
    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
    sys.exit(main())
```

[`entry_points`](https://packaging.python.org/guides/distributing-packages-using-setuptools/#entry-points) is cross-platform, as opposed to `scripts` (see previous link). Here is how it looks when installing:

```
$ pip install .                                    
Defaulting to user installation because normal site-packages is not writeable
Processing /Users/asmith/Documents/projects/PycharmProjects/alkaline-ml/giovanni
Requirement already satisfied: numpy<1.19.0 in /Library/Python/3.7/site-packages (from giovanni==0.0.0) (1.18.2)
Requirement already satisfied: tqdm in /Users/asmith/Library/Python/3.7/lib/python/site-packages (from giovanni==0.0.0) (4.55.0)
Requirement already satisfied: pandas in /Users/asmith/Library/Python/3.7/lib/python/site-packages (from giovanni==0.0.0) (1.1.0)
Requirement already satisfied: numpy<1.19.0 in /Library/Python/3.7/site-packages (from giovanni==0.0.0) (1.18.2)
Requirement already satisfied: python-dateutil>=2.7.3 in /Users/asmith/Library/Python/3.7/lib/python/site-packages (from pandas->giovanni==0.0.0) (2.8.1)
Requirement already satisfied: pytz>=2017.2 in /Users/asmith/Library/Python/3.7/lib/python/site-packages (from pandas->giovanni==0.0.0) (2020.1)
Requirement already satisfied: six>=1.5 in /Library/Python/3.7/site-packages (from python-dateutil>=2.7.3->pandas->giovanni==0.0.0) (1.10.0)
Building wheels for collected packages: giovanni
  Building wheel for giovanni (setup.py) ... done
  Created wheel for giovanni: filename=giovanni-0.0.0-py3-none-any.whl size=10308 sha256=14e9628f8e98eae75190c90e6a9df06d1fdeca3bff6b261eb3ae2761a6de3c0e
  Stored in directory: /private/var/folders/fg/v_4l41sj11qd899x387pgzyh0000gp/T/pip-ephem-wheel-cache-99agbp_n/wheels/02/3d/cf/9be299619b1047fdae57c3fb9dc37ee6d8f7b128e6b3f7b761
Successfully built giovanni
Installing collected packages: giovanni
Successfully installed giovanni-0.0.0
WARNING: You are using pip version 20.3.1; however, version 20.3.3 is available.
You should consider upgrading via the '/Library/Developer/CommandLineTools/usr/bin/python3 -m pip install --upgrade pip' command.
$ giovanni odds --gen 4 --verbose
[DEBUG] 2020-12-26 19:06:20 [giovanni.cli.main] - Calling giovanni.cli.odds.do_call
[DEBUG] 2020-12-26 19:06:20 [giovanni.cli.odds] - Num soft resets: 1
[DEBUG] 2020-12-26 19:06:20 [giovanni.cli.odds] - Swarm size: 1
[DEBUG] 2020-12-26 19:06:20 [giovanni.cli.odds] - Shiny charm: False
[DEBUG] 2020-12-26 19:06:20 [giovanni.cli.odds] - Generation: 4 (base rate=0.000122)
[INFO] 2020-12-26 19:06:20 [giovanni.cli.odds] - Odds of shiny after 1 soft reset: 0.012%
```

Closes #2 

